### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Swift developed based on AVPlayer iOS player,support horizontal gestures Fast fo
 ## Requirements
 -	Swift 3
 -	iOS 8.0+
--	XCode 8
+-	Xcode 8
 
 ## Features
 - [x] Support play local and network 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/
Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
